### PR TITLE
update fontawesome to allow for more badges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,9 +67,9 @@
       }
     },
     "@fortawesome/fontawesome-free": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
-      "integrity": "sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg=="
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.2.tgz",
+      "integrity": "sha512-7l/AX41m609L/EXI9EKH3Vs3v0iA8tKlIOGtw+kgcoanI7p+e4I4GYLqW3UXWiTnjSFymKSmTTPKYrivzbxxqA=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "^7.0.0"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.13.0",
+    "@fortawesome/fontawesome-free": "^5.15.2",
     "dompurify": "^2.0.11",
     "flag-icon-css": "^3.4.6",
     "marked": "^1.1.0",


### PR DESCRIPTION
`update fontawesome` to allow for badges of  all icons listed on https://fontawesome.com/cheatsheet/free/brands
Currently only the subset in the version `5.13.0` can be used (`!team rust` does not work).